### PR TITLE
NetEEPROM: Add library.properties

### DIFF
--- a/libraries/NetEEPROM/library.properties
+++ b/libraries/NetEEPROM/library.properties
@@ -1,0 +1,9 @@
+name=NetEEPROM(Ariadne-Bootloader)
+version=1.0.0
+author=Stylianos Tsampas
+maintainer=
+sentence=Set or display the network settings of the Ariadne bootloader.
+paragraph=
+category=Other
+url=https://github.com/codebendercc/Ariadne-Bootloader
+architectures=avr


### PR DESCRIPTION
A completely [different NetEEPROM](https://github.com/gregington/NetEEPROM) library was added to Library Manager so a unique library.properties name value for the Ariadne NetEEPROM library is necessary to avoid NetEEPROM appearing as Type: Updatable in Arduino IDE Library Manager and receiving spurious updatable library notifications in Arduino IDE 1.6.6+. If the "update" is installed it will override the Ariadne version of NetEEPROM.
![clipboard02](https://cloud.githubusercontent.com/assets/8572152/13489149/2fd903d8-e0da-11e5-8b29-08bda170dc59.gif)

I'm happy to make any changes requested and squash to a single commit.